### PR TITLE
Improve precompilation skip logic

### DIFF
--- a/spec/system/support/precompile_assets.rb
+++ b/spec/system/support/precompile_assets.rb
@@ -3,10 +3,16 @@
 # Precompile assets before running tests to avoid timeouts.
 # Do not precompile if webpack-dev-server is running (NOTE: MUST be launched with RAILS_ENV=test)
 RSpec.configure do |config|
-  # Skip assets precompilcation if we exclude system specs.
-  next if config.filter.opposite.rules[:type] == "system" || config.exclude_pattern.match?(%r{spec/system})
 
   config.before(:suite) do
+    
+    examples = RSpec.world.filtered_examples.values.flatten
+    has_no_system_tests = examples.none? { |example| example.metadata[:type] == :system }
+    if has_no_system_tests
+      $stdout.puts "\n🚀️️  No system test selected. Skip assets compilation.\n"
+      next
+    end
+    
     if Webpacker.dev_server.running?
       $stdout.puts "\n⚙️  Webpack dev server is running! Skip assets compilation.\n"
       next


### PR DESCRIPTION
I did not know where to put this suggestions but considering your blog post references this file I'm making a PR here :) 

This change is a more robust way of detecting if a system test has been selected because it will work with all the filtering techniques of rspec, not only the tag mechanism.
It is negligeably slower than your previous mechanism but much more robust.

On my project, I'm also using this second check for onlyprecompiling if a change has happened.
It is relying on `gfind` being available on macos system and therefore I cannot suggets it as a PR, but maybe you'll find this useful nonetheless :

```
    find_command = RUBY_PLATFORM =~ /darwin/ ? 'gfind' : 'find'
    rails_config = Rails.application.config
    find_latest_mtime = ->(paths) do
      paths_mtime_and_files = paths.map do |path|
        next nil unless Pathname(path).exist?
        latest_mtime_and_file = `#{find_command} '#{path}' -type f -printf '%T@\t%p\n' | sort -r -k1 | head -n1`
        latest_mtime_and_file
      end
      paths_mtime_and_files.compact.max
    end

    sprockets_paths = rails_config.assets.paths
    assets_paths = sprockets_paths + [ Webpacker.config.source_path ]
    latest_assets_mtime_and_file = find_latest_mtime.(assets_paths)

    public_path = rails_config.paths['public'].first
    compiled_asset_paths = [
      public_path + rails_config.assets.prefix,
      Webpacker.config.public_output_path.to_s,
    ]
    latest_compiled_assets_mtime_and_file = find_latest_mtime.(compiled_asset_paths)
```
...
```
...
    elsif latest_assets_mtime_and_file < latest_compiled_assets_mtime_and_file
      $stdout.puts "\n🚀   No need to recompile, latest assets are no more recent than latest compiled assets.\n"
      next
    else
...
```

I'm checking both sprockets and webpacker output directories because I'm running `assets:precompile` and not only `webpacker:compile` but feel free to adapt :)