### PR TITLE
change from path to url for workspace visit

### DIFF
--- a/spec/system/chat/messaging_spec.rb
+++ b/spec/system/chat/messaging_spec.rb
@@ -32,7 +32,7 @@ describe "Workspaces -> Chat" do
       within_session :john do
         login_user "John"
 
-        visit workspace_path(workspaces(:demo))
+        visit workspace_url(workspaces(:demo))
         expect(page).to have_text "Demo Workspace"
       end
     end


### PR DESCRIPTION
- Highlight an issue with rails `default_url_options`

Im working through a Minitest port and noticed `default_url_options` wasnt working properly. 

Creating a PR to see if it works correctly here.