### PR TITLE
Msgpack protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 4.0.0'
+
+  # Rack-based AnyCable server implementation
+  gem 'anycable-rack-server', '~> 0.4.0'
+  gem 'msgpack', '~> 1.4'
 end
 
 group :development do
@@ -33,10 +37,6 @@ end
 group :test do
   gem 'capybara'
   gem 'cuprite'
-
-  # Rack-based AnyCable server implementation
-  gem 'anycable-rack-server', '~> 0.4.0'
-  gem 'msgpack', '~> 1.4'
 
   gem 'test-prof'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,8 @@ group :test do
   gem 'cuprite'
 
   # Rack-based AnyCable server implementation
-  gem 'anycable-rack-server', '~> 0.3.0'
+  gem 'anycable-rack-server', '~> 0.4.0'
+  gem 'msgpack', '~> 1.4'
 
   gem 'test-prof'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     anycable-core (1.1.0.rc1)
       anyway_config (>= 2.1.0)
       google-protobuf (>= 3.13)
-    anycable-rack-server (0.3.0)
+    anycable-rack-server (0.4.0)
       anycable (> 1.0.99, < 2.0)
       anyway_config (>= 2.1.0)
       connection_pool (~> 2.2)
@@ -307,12 +307,13 @@ PLATFORMS
 
 DEPENDENCIES
   anycable (> 1.0.99)
-  anycable-rack-server (~> 0.3.0)
+  anycable-rack-server (~> 0.4.0)
   anycable-rails (> 1.0.99)
   bootsnap (>= 1.4.2)
   capybara
   cuprite
   listen
+  msgpack (~> 1.4)
   nanoid
   pry-byebug
   pry-rails

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
-server: bundle exec rails s
+server: bundle exec rails s -p 3000
 assets: bundle exec bin/webpack-dev-server
-ws: anycable-go --port=8080 --broadcast_adapter=http

--- a/config/anycable.yml
+++ b/config/anycable.yml
@@ -29,6 +29,7 @@ default: &default
 development:
   <<: *default
   embedded: true
+  http_broadcast_url: "http://localhost:3000/_anycable_rack_broadcast"
 
 test:
   <<: *default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,9 +2,14 @@
 
 Rails.application.configure do
   # Specify AnyCable WebSocket server URL to use by JS client
-  config.after_initialize do
-    config.action_cable.url = ActionCable.server.config.url = ENV.fetch("CABLE_URL", "ws://localhost:8080/cable") if AnyCable::Rails.enabled?
-  end
+  config.action_cable.url = ENV.fetch("CABLE_URL", "/rack_cable")
+  # Disable built-in Action Cable
+  config.action_cable.mount_path = nil
+  # Run AnyCable Rack server at a custom path
+  config.any_cable_rack.mount_path = "/rack_cable"
+  # Use Msgpack coder
+  config.any_cable_rack.coder = :msgpack
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,6 +14,8 @@ Rails.application.configure do
   config.action_cable.mount_path = nil
   # Run AnyCable Rack server at a custom path
   config.any_cable_rack.mount_path = "/rack_cable"
+  # Use Msgpack coder
+  config.any_cable_rack.coder = :msgpack
 
   # Settings specified here will take precedence over those in config/application.rb.
   config.cache_classes = true

--- a/frontend/utils/cable.js
+++ b/frontend/utils/cable.js
@@ -1,10 +1,13 @@
-import { createConsumer } from "@rails/actioncable";
+import { createConsumer, logger, adapters, INTERNAL } from "@rails/actioncable";
+import msgpack from "@ygoe/msgpack";
 
 let consumer;
 
 export const createCable = () => {
   if (!consumer) {
     consumer = createConsumer();
+    Object.assign(consumer.connection, connectionExtension);
+    Object.assign(consumer.connection.events, connectionEventsExtension);
   }
 
   return consumer;
@@ -13,4 +16,69 @@ export const createCable = () => {
 export const createChannel = (...args) => {
   const consumer = createCable();
   return consumer.subscriptions.create(...args);
+};
+
+// Msgpack support
+// Patches this file: https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/connection.js
+
+// Replace JSON protocol with msgpack
+const supportedProtocols = [
+  "actioncable-v1-msgpack"
+]
+
+const protocols = supportedProtocols
+const { message_types } = INTERNAL
+
+const connectionExtension = {
+  open() {
+    if (this.isActive()) {
+      logger.log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`)
+      return false
+    } else {
+      logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`)
+      if (this.webSocket) { this.uninstallEventHandlers() }
+      this.webSocket = new adapters.WebSocket(this.consumer.url, protocols)
+      this.webSocket.binaryType = "arraybuffer"
+      this.installEventHandlers()
+      this.monitor.start()
+      return true
+    }
+  },
+  isProtocolSupported() {
+    return supportedProtocols[0] == this.getProtocol()
+  },
+  send(data) {
+    if (this.isOpen()) {
+      const encoded = msgpack.encode(data);
+      this.webSocket.send(encoded)
+      return true
+    } else {
+      return false
+    }
+  }
+}
+
+// Incoming messages are handled by the connection.events.message function.
+// There is no way to patch it, so, we have to copy-paste :(
+const connectionEventsExtension = {
+  message(event) {
+    if (!this.isProtocolSupported()) { return }
+    const {identifier, message, reason, reconnect, type} = msgpack.decode(new Uint8Array(event.data))
+    switch (type) {
+      case message_types.welcome:
+        this.monitor.recordConnect()
+        return this.subscriptions.reload()
+      case message_types.disconnect:
+        logger.log(`Disconnecting. Reason: ${reason}`)
+        return this.close({allowReconnect: reconnect})
+      case message_types.ping:
+        return this.monitor.recordPing()
+      case message_types.confirmation:
+        return this.subscriptions.notify(identifier, "connected")
+      case message_types.rejection:
+        return this.subscriptions.reject(identifier)
+      default:
+        return this.subscriptions.notify(identifier, "received", message)
+    }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@rails/actioncable": "6.0.2",
     "@rails/ujs": "^6.0.3-4",
     "@rails/webpacker": "^6.0.0-beta.5",
+    "@ygoe/msgpack": "^1.0.2",
     "autoprefixer": "^10.2.5",
     "css-loader": "^5.1.3",
     "css-minimizer-webpack-plugin": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,6 +1158,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@ygoe/msgpack@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ygoe/msgpack/-/msgpack-1.0.2.tgz#7237b74179933bb9b73aa09d15d2a4414cfc7377"
+  integrity sha512-GXnUKo8aFiTE1RmhzGXzXNXoN500Zxe0FH62thZi18xI82N+Gcdw9MWjhV0SdTEfjHFwZiw0+ZJSE8sD02pRsQ==
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"


### PR DESCRIPTION
## Description

This PR demonstrates how to use Msgpack-encoded messages to communicate with AnyCable server.

**NOTE:** Msgpack is only supported by `anycable-rack-server` for now.

## Changes

- [x] Patched Action Cable client to use Msgpack instead of JSON to encode/decode messages
- [x] Migrated to anycable-rack-server in development
