### PR TITLE
Fix skipping precompile assets when dev server is running

### DIFF
--- a/spec/system/support/precompile_assets.rb
+++ b/spec/system/support/precompile_assets.rb
@@ -12,6 +12,14 @@ RSpec.configure do |config|
       next
     end
 
+    webpacker_dev_server_running = Webpacker::DevServer.new(
+      Webpacker::Configuration.new(
+        root_path: (root = Rails.root),
+        config_path: root.join('config', 'webpacker.yml'),
+        env: 'development'
+      )
+    ).running?
+
     if Webpacker.dev_server.running?
       $stdout.puts "\n⚙️  Webpack dev server is running! Skip assets compilation.\n"
       next

--- a/spec/system/support/precompile_assets.rb
+++ b/spec/system/support/precompile_assets.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
       )
     ).running?
 
-    if Webpacker.dev_server.running?
+    if webpacker_dev_server_running
       $stdout.puts "\n⚙️  Webpack dev server is running! Skip assets compilation.\n"
       next
     else

--- a/spec/system/support/precompile_assets.rb
+++ b/spec/system/support/precompile_assets.rb
@@ -14,8 +14,8 @@ RSpec.configure do |config|
 
     webpacker_dev_server_running = Webpacker::DevServer.new(
       Webpacker::Configuration.new(
-        root_path: (root = Rails.root),
-        config_path: root.join('config', 'webpacker.yml'),
+        root_path: (webpacker_cfg = Webpacker.config).root_path,
+        config_path: webpacker_cfg.config_path,
         env: 'development'
       )
     ).running?


### PR DESCRIPTION
Fixes #19 by adding the following changes:

- Adds a variable holding the real status of the dev server
- Use the fixed dev server check on precompile_assets.rb
