### PR TITLE
Instrumentation and monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,12 @@ gem 'ruby-next', '>= 0.10.0', require: false
 gem 'nanoid'
 gem 'turbo-rails'
 
+gem "yabeda-anycable"
+gem "yabeda-rails"
+gem "yabeda-puma-plugin"
+gem "yabeda-prometheus"
+gem "webrick" # For exporting metrics from AnyCable RPC
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       capybara (>= 2.1, < 4)
       ferrum (~> 0.11.0)
     diff-lcs (1.4.4)
+    dry-initializer (3.0.4)
     equalizer (0.0.11)
     erubi (1.10.0)
     ferrum (0.11)
@@ -122,6 +123,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    json (2.5.1)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -155,6 +157,7 @@ GEM
       ast (~> 2.4.1)
     pg (1.2.3)
     procto (0.0.3)
+    prometheus-client (2.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -286,11 +289,30 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    webrick (1.7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yabeda (0.10.0)
+      anyway_config (>= 1.3, < 3)
+      concurrent-ruby
+      dry-initializer
+    yabeda-anycable (0.1.0)
+      anycable-core (~> 1.1)
+      yabeda (~> 0.10)
+    yabeda-prometheus (0.7.0)
+      prometheus-client (>= 0.10, < 3.0)
+      rack
+      yabeda (~> 0.10)
+    yabeda-puma-plugin (0.6.0)
+      json
+      puma
+      yabeda (~> 0.5)
+    yabeda-rails (0.7.2)
+      rails
+      yabeda (~> 0.8)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -318,6 +340,11 @@ DEPENDENCIES
   test-prof
   turbo-rails
   webpacker (= 6.0.0.beta.6)
+  webrick
+  yabeda-anycable
+  yabeda-prometheus
+  yabeda-puma-plugin
+  yabeda-rails
 
 RUBY VERSION
    ruby 3.0.1p64

--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -1,0 +1,3 @@
+AnyCable.configure_server do
+  Yabeda::Prometheus::Exporter.start_metrics_server!
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -38,3 +38,7 @@ pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+activate_control_app
+plugin :yabeda
+plugin :yabeda_prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ x-backend: &backend
     EDITOR: vi
     LOG: ${LOG:-0}
     ACTION_CABLE_ADAPTER: ${ACTION_CABLE_ADAPTER:-anycable}
+    PROMETHEUS_EXPORTER_PORT: 5100
   depends_on: &backend_depends_on
     postgres:
       condition: service_healthy
@@ -92,6 +93,9 @@ services:
       ANYCABLE_REDIS_URL: redis://redis:6379/0
       ANYCABLE_RPC_HOST: anycable:50051
       ANYCABLE_DEBUG: 1
+      ANYCABLE_METRICS_HOST: "0.0.0.0"
+      ANYCABLE_METRICS_PORT: 5100
+      ANYCABLE_METRICS_HTTP: /metrics
     depends_on:
       redis:
         condition: service_healthy
@@ -176,6 +180,33 @@ services:
       # https://docs.browserless.io/docs/docker.html#connection-timeout
       CONNECTION_TIMEOUT: 600000
 
+  prometheus:
+    image: prom/prometheus:v2.29.1
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+    depends_on:
+      rails:
+        condition: service_started
+      anycable:
+        condition: service_started
+
+  grafana:
+    image: grafana/grafana:8.1.1
+    ports:
+      - "5000:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - grafana:/var/lib/grafana
+    user: "472"
+    depends_on:
+      prometheus:
+        condition: service_started
+
 volumes:
   postgres:
   redis:
@@ -184,3 +215,4 @@ volumes:
   rails_cache:
   packs:
   packs-test:
+  grafana:

--- a/grafana/dashboards/anycable_rpc.json
+++ b/grafana/dashboards/anycable_rpc.json
@@ -1,0 +1,284 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.6.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "doc",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "yabeda-anycable",
+      "tooltip": "Open anycable-yabeda homepage and docs",
+      "type": "link",
+      "url": "https://github.com/yabeda-rb/yabeda-anycable"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 23,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum(rate(anycable_rpc_call_runtime_seconds_bucket[1m])) by (method,command,le))",
+          "interval": "",
+          "legendFormat": "{{method}}: {{command}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "RPC call runtime (95th percentile)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 23,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(anycable_rpc_call_count[1m])) by (method, command, status)",
+          "interval": "",
+          "legendFormat": "{{method}}: {{command}} ({{status}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "RPC call throughput",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "AnyCable RPC",
+  "uid": "yabeda-anycable",
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/all.yml
+++ b/grafana/provisioning/dashboards/all.yml
@@ -1,0 +1,6 @@
+- name: 'default'       # name of this dashboard configuration (not dashboard itself)
+  org_id: 1             # id of the org to hold the dashboard
+  folder: ''            # name of the folder to put the dashboard (http://docs.grafana.org/v5.0/reference/dashboard_folders/)
+  type: 'file'          # type of dashboard description (json files)
+  options:
+    folder: '/var/lib/grafana/dashboards'       # where dashboards are

--- a/grafana/provisioning/datasources/all.yml
+++ b/grafana/provisioning/datasources/all.yml
@@ -1,0 +1,11 @@
+# https://github.com/cirocosta/sample-grafana/blob/master/grafana/provisioning/datasources/all.yml
+
+datasources:
+  -  access: 'proxy'                       # make grafana perform the requests
+     editable: true                        # whether it should be editable
+     is_default: true                      # whether this should be the default DS
+     name: 'prometheus'                    # name of the datasource
+     org_id: 1                             # id of the organization to tie this datasource to
+     type: 'prometheus'                    # type of the data source
+     url: 'http://prometheus:9090'         # url of the prom instance
+     version: 1                            # well, versioning

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: 'rails'
+    scheme: http
+    metrics_path: '/metrics'
+    static_configs:
+      - targets:
+          - 'rails:5100'
+  - job_name: 'anycable_rpc'
+    scheme: http
+    metrics_path: '/metrics'
+    static_configs:
+      - targets:
+          - 'anycable:5100'
+  - job_name: 'anycable_go'
+    scheme: http
+    metrics_path: '/metrics'
+    static_configs:
+      - targets:
+          - 'ws:5100'


### PR DESCRIPTION
## Description
 
This PR demonstrates how to add instrumentation to Rails project with AnyCable using [Yabeda](https://github.com/yabeda-rb/) and gives you local playground for monitoring.

## How to use this example?

 1. Start application with new `prometheus` and `grafana` components

    ```sh
    dip up rails anycable grafana prometheus
    ```

 2. Open Grafana at http://localhost:5000/ (login `admin`, password `admin`) and navigate to Dashboards → Manage.

 	Or just open dashboards on direct links:

 	 - AnyCable RPC: http://localhost:5000/d/yabeda-anycable/anycable-rpc

 3. Open demo application in other tabs or browsers, and look on beutiful graphs in Grafana!

## Progress

 - [x] Run Prometheus in Docker, setup metrics collection from other components (in production you will probably have it setup independently from your app)
 - [x] Run Grafana in Docker, configure it with Prometheus and provisioned dashboards (in production you will probably have it setup independently from your app) 
 - [x] Enable [AnyCable Go instrumentation](https://docs.anycable.io/anycable-go/instrumentation)
 - [x] Instrument AnyCable RPC with [yabeda-anycable](https://github.com/yabeda-rb/yabeda-anycable) gem and expose metrics with [yabeda-prometheus](https://github.com/yabeda-rb/yabeda-prometheus)
 - [x] Instrument web server with [yabeda-rails](https://github.com/yabeda-rb/yabeda-rails) and [yabeda-puma-plugin](https://github.com/yabeda-rb/yabeda-puma-plugin) metrics
 - [ ] Get metrics about CPU and RAM usage (TODO: research)
 - [x] Add dashboard for AnyCable RPC
 - [ ] Add dashboard for AnyCable Go
 - [ ] Add dashboard for Rails and Puma
 - [ ] Add dashboard for CPU and RAM


<details>
<summary>Technical implementation details</summary>

Materials used:

 - Monitoring with Prometheus, Grafana & Docker Part 1: https://finestructure.co/blog/2016/5/16/monitoring-with-prometheus-grafana-docker-part-1
 - How to automatically provision Grafana with dashboards: https://ops.tips/blog/initialize-grafana-with-preconfigured-dashboards/
 - Grafana provisioning docs: https://grafana.com/docs/grafana/latest/administration/provisioning/
 - Grafana docker image configuration: https://grafana.com/docs/grafana/latest/administration/configure-docker/

Debugging:

 - Check that Prometheus have all targets in “up” state at http://localhost:9090/targets

 </details>
 