### PR TITLE
Simplified Heroku deployment

### DIFF
--- a/.docker/Dockerfile.heroku
+++ b/.docker/Dockerfile.heroku
@@ -1,0 +1,4 @@
+ARG ANYCABLE_GO_TAG=latest
+
+FROM anycable/anycable-go:$ANYCABLE_GO_TAG
+LABEL maintainer="Vladimir Dementyev <palkan@hey.com>"

--- a/.slug-post-clean
+++ b/.slug-post-clean
@@ -1,0 +1,3 @@
+node_modules
+frontend
+tmp

--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,3 @@
+.dockerdev
+.github
+.rubocop

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rails server -p $PORT -b 0.0.0.0
+release: bundle exec rails db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec rails server -p $PORT -b 0.0.0.0
-release: bundle exec rails db:migrate
+web: ./litestream restore -o ./db/any_rails_demo.sqlite3 s3://heroku-anycable-demo-db/any_rails_demo.sqlite3 && ./litestream replicate -exec "bundle exec rails server -p $PORT -b 0.0.0.0" /app/db/any_rails_demo.sqlite3 s3://heroku-anycable-demo-db/any_rails_demo.sqlite3
+release: ./litestream restore -o ./db/any_rails_demo.sqlite3 s3://heroku-anycable-demo-db/any_rails_demo.sqlite3 && ./litestream replicate -exec "bundle exec rails heroku:release" /app/db/any_rails_demo.sqlite3 s3://heroku-anycable-demo-db/any_rails_demo.sqlite3

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,15 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
+
+namespace :heroku do
+  task release: ["db:migrate"] do
+    # Seed database if empty
+    if Workspace.count.zero?
+      load "./db/seeds.rb"
+    end
+
+    # Wait for Litestream to catch up
+    sleep 5
+  end
+end

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,0 +1,11 @@
+# Download Litestream
+wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-amd64-static.tar.gz
+
+# Extract the archive
+tar -xzf litestream-v0.3.9-linux-amd64-static.tar.gz
+
+# Make the binary executable
+chmod +x litestream
+
+# Verify
+./litestream version

--- a/config/anycable.yml
+++ b/config/anycable.yml
@@ -24,11 +24,11 @@ default: &default
   broadcast_adapter: http
   # Use the same channel name for WebSocket server, e.g.:
   #   $ anycable-go --redis-channel="__anycable__"
-  redis_channel: "__anycable__"
+  # redis_channel: "__anycable__"
+  http_rpc_mount_path: "/_anycable"
 
 development:
   <<: *default
-  http_rpc_mount_path: "/_anycable"
 
 test:
   <<: *default
@@ -36,5 +36,3 @@ test:
 
 production:
   <<: *default
-  # Use Redis in production
-  broadcast_adapter: redis

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,4 +14,4 @@ test:
 
 production:
   <<: *default
-  adapter: postgresql
+  database: db/any_rails_demo.sqlite3

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,9 +24,15 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
+  config.session_store :cookie_store, key: "_anycable_v14_sid", domain: :all
+
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, s-maxage=31536000, max-age=15552000",
+    "Expires" => 1.year.from_now.to_formatted_s(:rfc822)
+  }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  config:
+    ANYCABLE_GO_TAG: 1.4.0-rc.3
+  docker:
+    web: .docker/Dockerfile.heroku


### PR DESCRIPTION
## Description

This PR contains the required changes to add AnyCable to a Rails app running on Heroku with [RPC over HTTP](https://docs.anycable.io/edge/ruby/http_rpc). In this setup, AnyCable-Go can be deployed independently as a standalone service (compared to previous version with a combined RPC-WS app, see #4).

Based on [the official guide](https://docs.anycable.io/edge/deployment/heroku).

**NOTE:** This PR's branched out from the _dockerless_ version (#1).

## Changes

- [x] Added base Heroku Procfile.
- [x] Enabled HTTP RPC (by setting `http_rpc_mount_path` in the `anycable.yml`) 
- [x] Configured session cookies.
- [x] Added `heroku.yml` and a corresponding Dockerfile to the repo.

Irrelevant:

- [x] Configured [Litestream](https://litestream.io) to _persiste_ sqlite database on Heroku