### PR TITLE
Qovery deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more about ignoring files.
+
+# Ignore git directory.
+/.git/
+
+# Ignore bundler config.
+/.bundle
+
+# Ignore all environment files (except templates).
+/.env*
+!/.env*.erb
+
+# Ignore all default key files.
+/config/master.key
+/config/credentials/*.key
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/.keep
+
+# Ignore storage (uploaded files in development and any SQLite databases).
+/storage/*
+!/storage/.keep
+/tmp/storage/*
+!/tmp/storage/.keep
+
+# Ignore assets.
+/node_modules/
+/app/assets/builds/*
+!/app/assets/builds/.keep
+/public/assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+# syntax = docker/dockerfile:experimental
+ARG RUBY_VERSION=3.2.1
+ARG DISTRO_NAME=bullseye
+
+FROM ruby:$RUBY_VERSION-slim-$DISTRO_NAME
+
+ARG DISTRO_NAME
+
+# Common dependencies
+# Using --mount to speed up build with caching, see https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mount
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/var/log \
+  rm -f /etc/apt/apt.conf.d/docker-clean; \
+  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
+  apt-get update -qq && \
+  DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    build-essential \
+    gnupg2 \
+    curl \
+    less \
+    git
+
+ARG PG_MAJOR=15
+RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgres-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/postgres-archive-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/" \
+    $DISTRO_NAME-pgdg main $PG_MAJOR | tee /etc/apt/sources.list.d/postgres.list > /dev/null
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/var/log \
+  apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    libpq-dev \
+    postgresql-client-$PG_MAJOR
+
+ARG NODE_MAJOR=18
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=tmpfs,target=/var/log \
+    apt-get update && \
+    apt-get install -y curl software-properties-common && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    echo "deb https://deb.nodesource.com/node_${NODE_MAJOR}.x $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends nodejs
+
+ARG YARN_VERSION=latest
+RUN npm install -g yarn@$YARN_VERSION
+
+# Configure bundler
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development"
+
+# Store Bundler settings in the project's root
+ENV BUNDLE_APP_CONFIG=.bundle
+
+# Upgrade RubyGems and install latest Bundler
+RUN gem update --system && \
+    gem install bundler
+
+# Create a directory for the app code
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs 4 --retry 3
+
+COPY . .
+
+RUN SECRET_KEY_BASE=1 CABLE_URL=ws://fake.local bundle exec rails assets:precompile
+
+ENV RAILS_SERVE_STATIC_FILES=true
+ENV RAILS_LOG_TO_STDOUT=true
+
+# Entrypoint prepares the database.
+ENTRYPOINT ["/app/bin/docker-entrypoint"]
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 3000
+CMD ["./bin/rails", "server"]

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# If running the rails server then create or migrate existing database
+if [ "${*}" == "./bin/rails server" ]; then
+  ./bin/rails db:prepare
+fi
+
+exec "${@}"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,6 +5,10 @@ Rails.application.configure do
   config.after_initialize do
     config.action_cable.url = ActionCable.server.config.url = ENV.fetch("CABLE_URL") if AnyCable::Rails.enabled?
   end
+
+  # Configure session cookie to be stored for all subdomains
+  config.session_store :cookie_store, key: "_anycable_qovery_demo_sid", domain: :all
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -27,6 +31,10 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, s-maxage=31536000, max-age=15552000",
+    "Expires" => 1.year.from_now.to_formatted_s(:rfc822)
+  }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
## Description

This PR contains code changes and describes the required steps to deploy a Rails application with AnyCable on [Qovery][] (full mode, with gRPC service).

## Changes

- [x] Added Dockerfile
  - **Not production ready** The dockerfile is based on our development Dockerfile and is not optimized for production
  - We assume that you have your own Dockerfile (or use something like [dockerfile-rails][], or Rails 7.1 built-in template)
  - The only important piece of the Dockerfile is the usage of `bin/docker-entrypoint` script as an entrypoint (it's borrowed from Rails)
- [x] Minor production configuration changes (e.g., sharing cookies across subdomains to make authentication work with two hostnames, `web` and `ws`).

## Qovery tips

We tested our setup using Qovery playground cluster. The resulting formation is depicted below:

<img width="1173" alt="image" src="https://github.com/anycable/anycable_rails_demo/assets/1516722/a08a0c08-81ba-4a89-bb8e-253ef60635e6">

The `web` service is the default Rails web service.

The `rpc` service is a clone of the web service with the following changes:

- "CMD arguments" are set to `["bundle","exec","anycable","--rpc-host","0.0.0.0:50051"]` (to run AnyCable RPC server)
- Port is changed to 50051 GRPC
- gRPC healthchecks are configured for 50051 (Service: `anycable.RPC`)

The `ws` service is deployed directly from Dockerhub:

- Healthchecks are configured to use the `/health` HTTP endpoint.

The following environment variables have been set to connect services and databases:

- `DATABASE_URL` as an alias for `QOVERY_POSTGRESQL_<XXX>_DATABASE_URL_INTERNAL` (scope: Application)
- `REDIS_URL` as an alias for `QOVERY_REDIS_<XXX>_DATABASE_URL_INTERNAL` (scope: Application)

- `APPLICATION_RPC_HOST_INTERNAL` as an alias for `QOVERY_APPLICATION_<RPC_SERVICE_ID>_HOST_INTERNAL` (scope: Environment)
- `APPLICATION_WS_HOST_EXTERNAL` as an alias for `QOVERY_APPLICATION_<WS_SERVICE_ID>_HOST_EXTERNAL` (scope: Environment)

- `CABLE_URL` as `wss://${APPLICATION_WS_HOST_EXTERNAL}/cable` (scope: Environment)

- `ANYCABLE_RPC_HOST` as `{{APPLICATION_RPC_HOST_INTERNAL}}:50051` (scope: Service, `ws`)
- `ANYCABLE_HOST=0.0.0.0` (scope: Service, `ws`)

[Qovery]: https://www.qovery.com
[dockerfile-rails]: https://github.com/fly-apps/dockerfile-rails